### PR TITLE
Correctly validate 'content' payload type and fix typo

### DIFF
--- a/src/routes/api/string/index.test.ts
+++ b/src/routes/api/string/index.test.ts
@@ -33,6 +33,22 @@ describe('api/string', () => {
             });
         });
 
+        it('Should return a 400 Malformed input if the value of the "content" key is not a string', (done) => {
+            const chaiProm = chai
+                .request(app)
+                .post('/api/string/replace')
+                .set('Content-Type', 'application/json')
+                .set('x-api-key', 'helloworld')
+                .send(`{"content": {"yo": "yo"}}`);
+
+            chaiProm.end((err, res) => {
+                res.should.have.status(400);
+                res.body.should.have.property('message');
+                res.body.message.should.equal('Malformed Input');
+                done();
+            });
+        });
+
         it('Should return an empty string if an empty string is provided', (done) => {
             sendRequest('').end((err, res) => {
                 res.should.have.status(200);

--- a/src/routes/api/string/index.ts
+++ b/src/routes/api/string/index.ts
@@ -4,6 +4,6 @@ import { stringReplace } from '../../../controllers/stringManipulations';
 
 const router = Router();
 
-router.post('/replace', body('content').exists().trim().isString(), stringReplace);
+router.post('/replace', body('content').exists().isString(), stringReplace);
 
 export default router;

--- a/src/utils/routeLogger.ts
+++ b/src/utils/routeLogger.ts
@@ -11,7 +11,7 @@ export const routeLogger = (req: Request, res: Response, next: NextFunction) => 
     logger.info(
         `${req.method} ${req.path} params=${JSON.stringify(req.params)} body=${JSON.stringify(
             req.body
-        )}}`
+        )}`
     );
     return next();
 };


### PR DESCRIPTION
fix: Fixing typo in route logger and fixing the validation of the 'content' payload. The 'trim' before the 'isString' was converting the value in a string.